### PR TITLE
Add adventure blog website

### DIFF
--- a/adventure-blog/about.html
+++ b/adventure-blog/about.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About Us - Transit Trek Adventures</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>Transit Trek Adventures</h1>
+        <nav class="main-nav">
+            <a href="index.html">Home</a>
+            <a href="blog.html">Blog</a>
+            <a href="about.html" class="active">About</a>
+        </nav>
+    </header>
+
+    <section class="about">
+        <h2>Meet the Travelers</h2>
+        <p>
+            We're Joe and Jane, lifelong wanderers with a passion for exploring new places. Along for the ride is Thor,
+            our spirited Norwegian Elkhound who keeps us company on the road. Together, we're traveling the U.S. in our
+            trusty Ford Transit, seeking out hidden spots and meeting incredible people along the way.
+        </p>
+        <p>
+            Our van life journey is about more than just reaching destinations—it's about embracing the experiences we
+            find, sharing them with friends old and new, and living each day with curiosity.
+        </p>
+    </section>
+
+    <footer class="site-footer">
+        <p>&copy; 2024 Transit Trek Adventures</p>
+    </footer>
+</body>
+</html>

--- a/adventure-blog/blog.html
+++ b/adventure-blog/blog.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blog - Transit Trek Adventures</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>Transit Trek Adventures</h1>
+        <nav class="main-nav">
+            <a href="index.html">Home</a>
+            <a href="blog.html" class="active">Blog</a>
+            <a href="about.html">About</a>
+        </nav>
+    </header>
+
+    <section class="blog">
+        <article id="post1" class="post">
+            <h2>Setting Off: Day One on the Road</h2>
+            <p class="date">June 4, 2024</p>
+            <p>
+                Our adventure begins! After months of planning, we finally packed up the Transit and started our trek
+                across the U.S. Thor immediately claimed the passenger seat, ears perked and ready for whatever lies ahead.
+            </p>
+        </article>
+
+        <article id="post2" class="post">
+            <h2>Finding Hidden Gems in Colorado</h2>
+            <p class="date">June 10, 2024</p>
+            <p>
+                Colorado welcomed us with crystal clear skies and towering peaks. We camped near an alpine lake and
+                spent the days hiking trails that seemed to go on forever. Thor couldn't get enough of the fresh mountain
+                air!
+            </p>
+        </article>
+    </section>
+
+    <footer class="site-footer">
+        <p>&copy; 2024 Transit Trek Adventures</p>
+    </footer>
+</body>
+</html>

--- a/adventure-blog/index.html
+++ b/adventure-blog/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transit Trek Adventures</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="site-header">
+        <h1>Transit Trek Adventures</h1>
+        <nav class="main-nav">
+            <a href="index.html">Home</a>
+            <a href="blog.html">Blog</a>
+            <a href="about.html">About</a>
+        </nav>
+    </header>
+
+    <section class="hero">
+        <h2>Exploring the U.S. in our Ford Transit</h2>
+        <p>Follow Joe, Jane, and Thor the Norwegian Elkhound as we journey across the country.</p>
+    </section>
+
+    <section class="intro">
+        <h3>Welcome to Our Adventure Blog</h3>
+        <p>
+            We're hitting the road in our custom Ford Transit to see what adventures await us. From the
+            national parks of the west to the coastal beaches of the east, we hope you'll join us for the ride.
+        </p>
+        <p>
+            Check out our latest posts below or visit the blog page for more stories from the road.
+        </p>
+    </section>
+
+    <section class="recent-posts">
+        <h3>Recent Posts</h3>
+        <article class="post">
+            <h4>Setting Off: Day One on the Road</h4>
+            <p class="date">June 4, 2024</p>
+            <p>
+                Today marks the beginning of our grand adventure. We loaded up the Transit, secured Thor's favorite spot
+                by the window, and hit the highway bound for the Rocky Mountains.
+            </p>
+            <a href="blog.html#post1" class="read-more">Read more...</a>
+        </article>
+        <article class="post">
+            <h4>Finding Hidden Gems in Colorado</h4>
+            <p class="date">June 10, 2024</p>
+            <p>
+                Tucked away in the Rockies, we discovered serene campsites and unforgettable hiking trails.
+                Thor has taken to the trails like a pro!
+            </p>
+            <a href="blog.html#post2" class="read-more">Read more...</a>
+        </article>
+    </section>
+
+    <footer class="site-footer">
+        <p>&copy; 2024 Transit Trek Adventures</p>
+    </footer>
+</body>
+</html>

--- a/adventure-blog/style.css
+++ b/adventure-blog/style.css
@@ -1,0 +1,88 @@
+body {
+    font-family: 'Roboto', sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.site-header {
+    background-color: #0a3d62;
+    color: white;
+    padding: 1rem 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.site-header h1 {
+    margin: 0;
+    font-size: 1.8rem;
+}
+
+.main-nav a {
+    color: white;
+    margin-left: 1rem;
+    text-decoration: none;
+    font-weight: 400;
+}
+
+.main-nav a.active,
+.main-nav a:hover {
+    text-decoration: underline;
+}
+
+.hero {
+    background-image: url('https://images.unsplash.com/photo-1502920514313-52581002a659?auto=format&fit=crop&w=1200&q=60');
+    background-size: cover;
+    background-position: center;
+    color: white;
+    padding: 4rem 2rem;
+    text-align: center;
+}
+
+.hero h2 {
+    font-size: 2.2rem;
+    margin-bottom: 0.5rem;
+}
+
+.intro,
+.blog,
+.about,
+.recent-posts {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+.post {
+    background: white;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.post h4, .post h2 {
+    margin-top: 0;
+}
+
+.post .date {
+    font-size: 0.9rem;
+    color: #777;
+}
+
+.read-more {
+    color: #0a3d62;
+    font-weight: 700;
+    text-decoration: none;
+}
+
+.site-footer {
+    background-color: #0a3d62;
+    color: white;
+    text-align: center;
+    padding: 1rem;
+    margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- build simple adventure travel site with a home page
- add About and Blog pages with sample content
- create shared stylesheet for basic styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684057f81fa8832ebd323dcc9df5c6fb